### PR TITLE
Check if position corresponds to a known opening even if play param is empty

### DIFF
--- a/src/opening.rs
+++ b/src/opening.rs
@@ -67,6 +67,10 @@ impl Openings {
     ) -> Result<Option<&Opening>, Error> {
         let mut opening = None;
 
+        if play.len() == 0 && opening_sensible(root.as_inner().variant()) {
+            opening = self.data.get(&root.zobrist_hash());
+        }
+
         for uci in play {
             let m = uci.to_move(root)?;
             root.play_unchecked(&m);


### PR DESCRIPTION
As indicated in https://github.com/lichess-org/lila/issues/11025, when working FromPosition the Opening Explorer doesn't show the opening name even if the position specified is a known one.

The problem happens because the response the frontend gets from the internal endpoint (https://explorer.lichess.ovh/masters) doesn't contain the opening itself, even though according to the [API docs](https://lichess.org/api#operation/openingExplorerMaster) it should if the FEN matches a known opening.

I have traced the issue to here and seen that if the endpoint receives an empty _play_ parameter, it won't try to match the position to an opening and just return None. Therefore, I've added this couple of lines to try to match the position to an opening if the _play_ parameter is empty.

