### PR TITLE
Add admin api route to update cf_masters_game

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,6 +1185,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1240,6 +1262,7 @@ dependencies = [
  "fastrand",
  "futures-util",
  "iai",
+ "json-patch",
  "log",
  "moka",
  "nohash-hasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ csv = "1"
 env_logger = "0.11"
 fastrand = "2"
 futures-util = "0.3"
+json-patch ="4"
 log = "0.4"
 moka = { version = "0.12", features = ["future"] }
 nohash-hasher = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ csv = "1"
 env_logger = "0.11"
 fastrand = "2"
 futures-util = "0.3"
-json-patch ="4"
+json-patch = "4"
 log = "0.4"
 moka = { version = "0.12", features = ["future"] }
 nohash-hasher = "0.2"

--- a/src/db.rs
+++ b/src/db.rs
@@ -360,6 +360,14 @@ impl MastersDatabase<'_> {
             .collect()
     }
 
+    pub fn put_game(&self, id: GameId, game: &MastersGame) -> Result<(), rocksdb::Error> {
+        self.inner.put_cf(
+            self.cf_masters_game,
+            id.to_bytes(),
+            serde_json::to_vec(game).expect("serialize masters game"),
+        )
+    }
+
     pub fn has(&self, key: Key) -> Result<bool, rocksdb::Error> {
         self.inner
             .get_pinned_cf(self.cf_masters, key.into_bytes())

--- a/src/main.rs
+++ b/src/main.rs
@@ -630,9 +630,10 @@ async fn masters_game_update(
     Path(MastersGameId(id)): Path<MastersGameId>,
     State(db): State<Arc<Database>>,
     State(semaphore): State<&'static Semaphore>,
+    State(masters_cache): State<ExplorerCache<MastersQuery>>,
     Json(patch): Json<serde_json::Value>,
 ) -> Result<(), StatusCode> {
-    spawn_blocking(semaphore, move || {
+    let response = spawn_blocking(semaphore, move || {
         let masters_db = db.masters();
         let game = masters_db
             .game(id)
@@ -646,7 +647,9 @@ async fn masters_game_update(
         log::info!("updated masters game {id}");
         Ok(())
     })
-    .await
+    .await;
+    masters_cache.invalidate_all();
+    response
 }
 
 #[axum::debug_handler(state = AppState)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,7 @@ async fn serve() {
         .route("/import/lichess", put(lichess_import))
         .route("/import/openings", post(openings_import))
         .route("/masters/pgn/{id}", get(masters_pgn))
+        .route("/masters/game/{id}", put(masters_game_update))
         .route("/masters", get(masters))
         .route("/lichess", get(lichess))
         .route("/lichess/history", get(lichess_history)) // bc
@@ -620,6 +621,30 @@ async fn masters_pgn(
             Some(game) => Ok(game),
             None => Err(StatusCode::NOT_FOUND),
         }
+    })
+    .await
+}
+
+#[axum::debug_handler(state = AppState)]
+async fn masters_game_update(
+    Path(MastersGameId(id)): Path<MastersGameId>,
+    State(db): State<Arc<Database>>,
+    State(semaphore): State<&'static Semaphore>,
+    Json(patch): Json<serde_json::Value>,
+) -> Result<(), StatusCode> {
+    spawn_blocking(semaphore, move || {
+        let masters_db = db.masters();
+        let game = masters_db
+            .game(id)
+            .expect("get masters game")
+            .ok_or(StatusCode::NOT_FOUND)?;
+        let mut value = serde_json::to_value(game).expect("serialize masters game");
+        json_patch::merge(&mut value, &patch);
+        let updated: MastersGame =
+            serde_json::from_value(value).map_err(|_| StatusCode::BAD_REQUEST)?;
+        masters_db.put_game(id, &updated).expect("put masters game");
+        log::info!("updated masters game {id}");
+        Ok(())
     })
     .await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use axum::{
     Json, Router,
     extract::{FromRef, Path, Query, State},
     http::StatusCode,
-    routing::{get, post, put},
+    routing::{get, patch, post, put},
 };
 use clap::Parser;
 use futures_util::{StreamExt, stream::Stream};
@@ -147,10 +147,10 @@ async fn serve() {
         .route("/monitor", get(monitor))
         .route("/compact", post(compact))
         .route("/import/masters", put(masters_import))
+        .route("/import/masters/{id}", patch(masters_game_update))
         .route("/import/lichess", put(lichess_import))
         .route("/import/openings", post(openings_import))
         .route("/masters/pgn/{id}", get(masters_pgn))
-        .route("/masters/game/{id}", put(masters_game_update))
         .route("/masters", get(masters))
         .route("/lichess", get(lichess))
         .route("/lichess/history", get(lichess_history)) // bc


### PR DESCRIPTION
Adds `PUT /masters/game/{id}` to update masters game metadata.

I added a crate (https://docs.rs/json-patch/latest/json_patch/) to handle partial JSON merges to allow updating only one field in the request instead of sending the entire JSON.

Closes #326.